### PR TITLE
Add CGO_ENABLED environment variable to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: wangyoucao577/go-release-action@v1.38
+      env:
+        CGO_ENABLED: 0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}


### PR DESCRIPTION
修改原因：
vault官方提供的docker版本依赖于Alpine Linux，使用了 `musl libc`，与ubuntu的libc不兼容。

需要将插件编译为静态二进制文件，不依赖任何第三方库，才能正常运行。

个人在 Linux Docker的AMD版本进行了测试，通过 `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o vault-gmsm-plugin .` 命令编译插件才可以正常使用。

根据AI建议在workflow里增加了环境变量，希望能有帮助。